### PR TITLE
fix typo in error message

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -89,7 +89,7 @@ function handleRequest(data: WorkerRequestMessage): WorkerResponseMessage {
   if (rule.type === "map" && rule.neighbors !== "moore") {
     return {
       kind: "response-error",
-      message: "Non Moore neighborhood is not suuported for MAP rules",
+      message: "Non Moore neighborhood is not supported for MAP rules",
     };
   }
 


### PR DESCRIPTION
x = 1, y = 38, rule = MAPBJ8g/wSfIP8EnyD/AP8A/w
o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o$o
$o$o$o!
<img width="793" height="337" alt="image" src="https://github.com/user-attachments/assets/aafa644a-66bf-4192-8dfb-55ee7b06e00c" />

"suuported" --> "supported"