### PR TITLE
fix: pixelated canvas

### DIFF
--- a/pages/changelog/index.html
+++ b/pages/changelog/index.html
@@ -32,6 +32,7 @@
               Allow infinite grid. <br />
               ":P0,0" and ":T0,0"
             </li>
+            <li>Reduce blur of the map.</li>
           </ul>
         </div>
         <div>

--- a/src/style.css
+++ b/src/style.css
@@ -7,6 +7,7 @@
 canvas {
   outline: none;
   margin: auto;
+  image-rendering: pixelated;
 }
 
 body {

--- a/src/ui/map-canvas-ui.ts
+++ b/src/ui/map-canvas-ui.ts
@@ -8,10 +8,10 @@ import type { AnalyzeResult } from "../lib/analyzeOscillator";
 import type { MapType } from "./core";
 
 const safeArea = 2;
-const cellSize = 20;
-const innerCellSize = 12;
+const cellSize = 10;
+const innerCellSize = 6;
 const innerCellOffset = (cellSize - innerCellSize) / 2;
-const gridWidth = 2;
+const gridWidth = 1;
 
 export class MapCanvasUI {
   private $canvas: HTMLCanvasElement;


### PR DESCRIPTION
blur can be avoided by https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering

```txt
x = 3, y = 3, rule = B3/S23
2o$2o!
```

Before
<img width="799" height="394" alt="スクリーンショット 2025-09-28 10 31 48" src="https://github.com/user-attachments/assets/e36112da-88ef-4caa-b688-000387ec3de6" />

After

<img width="771" height="499" alt="スクリーンショット 2025-09-28 10 31 36" src="https://github.com/user-attachments/assets/2af061da-11b4-4b65-b87a-6ba0d0b2e06d" />

